### PR TITLE
Correção da validação de data inicial + implementação de método para listar todos os eventos

### DIFF
--- a/Controllers/SingletonDataController.cs
+++ b/Controllers/SingletonDataController.cs
@@ -84,6 +84,11 @@ public class SingletonDataController
         return eventosNaData;
     }
 
+    public List<Evento> BuscaListaDeEventos()
+    {
+        return singletonData.ObterEventos();
+    }
+
     public Contato BuscaContato(string nome)
     {
         Contato? contato = null;
@@ -141,7 +146,7 @@ public class SingletonDataController
         return singletonData.GetIdsGerados().Contains(id);
     }
 
-    public bool ListaDeEventosVazia()
+    public bool VerificaListaDeEventosVazia()
     {
         if (singletonData.ObterEventos().Count == 0)
         {

--- a/Controllers/SingletonDataController.cs
+++ b/Controllers/SingletonDataController.cs
@@ -29,7 +29,6 @@ public class SingletonDataController
 
     public string AdicionarEvento()
     {
-
         try
         {
             singletonData.AdicionarEvento(ViewMenus.ObtemOpcoesAdicionarEvento());
@@ -140,5 +139,15 @@ public class SingletonDataController
     public bool VerificaExistenciaId(string id)
     {
         return singletonData.GetIdsGerados().Contains(id);
+    }
+
+    public bool ListaDeEventosVazia()
+    {
+        if (singletonData.ObterEventos().Count == 0)
+        {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/Controllers/SingletonViewController.cs
+++ b/Controllers/SingletonViewController.cs
@@ -48,6 +48,9 @@ public class SingletonViewController
                 case 3:
                     BuscaEExibeContato();
                     break;
+                case 4:
+                    BuscaEExibeEventosCadastrados();
+                    break;
                 default:
                     Console.WriteLine("Opção digitada não é valida!");
                     break;
@@ -125,5 +128,10 @@ public class SingletonViewController
         string nomeEncontrado = singletonDataController.BuscaContato(nome).ToString();
 
         Console.WriteLine(nomeEncontrado == null ? "Nenhum contato encontrado!" : nomeEncontrado);
+    }
+
+    public void BuscaEExibeEventosCadastrados()
+    {
+        ViewData.ExibeListaDeEventos(singletonDataController.BuscaListaDeEventos());
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -18,7 +18,7 @@ public class Program
             string statusExecucao = null!;
             opcao = ViewMenus.ObtemOpcoesMenuPrincipal();
 
-            if (opcao > 1 && sdc.ListaDeEventosVazia()) 
+            if (opcao > 1 && sdc.VerificaListaDeEventosVazia()) 
             {
                 Console.WriteLine("Ainda não há eventos cadastrados! ");
                 Thread.Sleep(2000);

--- a/Program.cs
+++ b/Program.cs
@@ -17,6 +17,15 @@ public class Program
         {
             string statusExecucao = null!;
             opcao = ViewMenus.ObtemOpcoesMenuPrincipal();
+
+            if (opcao > 1 && sdc.ListaDeEventosVazia()) 
+            {
+                Console.WriteLine("Ainda não há eventos cadastrados! ");
+                Thread.Sleep(2000);
+                Console.Clear();
+                continue;
+            }
+
             switch (opcao)
             {
                 case 0:

--- a/Util/Input/Teclado.cs
+++ b/Util/Input/Teclado.cs
@@ -97,32 +97,7 @@ namespace Gestor_de_Eventos.Util.Input
             } while (!InputValidator.ValidaFormatoDataBrasileira(entrada));
 
             return DateOnly.ParseExact(entrada, ValidationPatterns.MascaraDataBrasileira, null);
-        }
-
-        //public static DateTime CapturaDataHoraDigitada()
-        //{
-        //    string entrada = null!;
-        //    int quantidadeTentativas = 0;
-        //    do
-        //    {
-        //        quantidadeTentativas++;
-        //        if (quantidadeTentativas > 1)
-        //        {
-        //            if (string.IsNullOrEmpty(entrada))
-        //            {
-        //                Console.WriteLine("Data e hora não podem ficar vazios!");
-        //            } else
-        //            {
-        //                Console.WriteLine("Date e hora devem possuir o formato dd/MM/yyyy HH:mm");
-        //            }
-        //        }
-        //        Console.Write("Digite aqui >>> ");
-        //        entrada = Console.ReadLine()!;
-        //        Console.WriteLine(" ");
-        //    } while (!InputValidator.ValidaFormatoDataHoraMinutoBrasileiro(entrada));
-
-        //    return DateTime.ParseExact(entrada, ValidationPatterns.MascaraDataHoraMinutoBrasileiro, null);
-        //}
+        }        
 
         public static DateTime CapturaDataHoraDigitadaMaiorQueDataEspecifica(DateTime dataEspecifica)
         {

--- a/Util/Input/Teclado.cs
+++ b/Util/Input/Teclado.cs
@@ -99,30 +99,30 @@ namespace Gestor_de_Eventos.Util.Input
             return DateOnly.ParseExact(entrada, ValidationPatterns.MascaraDataBrasileira, null);
         }
 
-        public static DateTime CapturaDataHoraDigitada()
-        {
-            string entrada = null!;
-            int quantidadeTentativas = 0;
-            do
-            {
-                quantidadeTentativas++;
-                if (quantidadeTentativas > 1)
-                {
-                    if (string.IsNullOrEmpty(entrada))
-                    {
-                        Console.WriteLine("Data e hora não podem ficar vazios!");
-                    } else
-                    {
-                        Console.WriteLine("Date e hora devem possuir o formato dd/MM/yyyy HH:mm");
-                    }
-                }
-                Console.Write("Digite aqui >>> ");
-                entrada = Console.ReadLine()!;
-                Console.WriteLine(" ");
-            } while (!InputValidator.ValidaFormatoDataHoraMinutoBrasileiro(entrada));
+        //public static DateTime CapturaDataHoraDigitada()
+        //{
+        //    string entrada = null!;
+        //    int quantidadeTentativas = 0;
+        //    do
+        //    {
+        //        quantidadeTentativas++;
+        //        if (quantidadeTentativas > 1)
+        //        {
+        //            if (string.IsNullOrEmpty(entrada))
+        //            {
+        //                Console.WriteLine("Data e hora não podem ficar vazios!");
+        //            } else
+        //            {
+        //                Console.WriteLine("Date e hora devem possuir o formato dd/MM/yyyy HH:mm");
+        //            }
+        //        }
+        //        Console.Write("Digite aqui >>> ");
+        //        entrada = Console.ReadLine()!;
+        //        Console.WriteLine(" ");
+        //    } while (!InputValidator.ValidaFormatoDataHoraMinutoBrasileiro(entrada));
 
-            return DateTime.ParseExact(entrada, ValidationPatterns.MascaraDataHoraMinutoBrasileiro, null);
-        }
+        //    return DateTime.ParseExact(entrada, ValidationPatterns.MascaraDataHoraMinutoBrasileiro, null);
+        //}
 
         public static DateTime CapturaDataHoraDigitadaMaiorQueDataEspecifica(DateTime dataEspecifica)
         {
@@ -136,7 +136,8 @@ namespace Gestor_de_Eventos.Util.Input
                     if (string.IsNullOrEmpty(entrada))
                     {
                         Console.WriteLine("Data e hora não podem ficar vazios!");
-                    } else if (!InputValidator.ValidaFormatoDataHoraMinutoBrasileiro(entrada))
+                    } 
+                    else if (!InputValidator.ValidaFormatoDataHoraMinutoBrasileiro(entrada))
                     {
                         Console.WriteLine("Date e hora devem possuir o formato dd/MM/yyyy HH:mm");
                     }
@@ -148,7 +149,7 @@ namespace Gestor_de_Eventos.Util.Input
                 Console.Write("Digite aqui >>> ");
                 entrada = Console.ReadLine()!;
                 Console.WriteLine(" ");
-            } while (!InputValidator.ValidaPeriodoDateTime(dataEspecifica, entrada));
+            } while (!InputValidator.ValidaFormatoDataHoraMinutoBrasileiro(entrada) || !InputValidator.ValidaPeriodoDateTime(dataEspecifica, entrada));
 
             return DateTime.ParseExact(entrada, ValidationPatterns.MascaraDataHoraMinutoBrasileiro, null);
         }

--- a/Views/ViewMenus.cs
+++ b/Views/ViewMenus.cs
@@ -157,8 +157,10 @@ internal class ViewMenus
     {
         Console.WriteLine("Informe o título do evento");
         string titulo = Teclado.CapturaStringDigitada();
+        //Console.WriteLine("Informe a Data Inicial");
+        //DateTime dataInicial = Teclado.CapturaDataHoraDigitada();
         Console.WriteLine("Informe a Data Inicial");
-        DateTime dataInicial = Teclado.CapturaDataHoraDigitada();
+        DateTime dataInicial = Teclado.CapturaDataHoraDigitadaMaiorQueDataEspecifica(DateTime.Now);
         Console.WriteLine("Informe a Data Final");
         DateTime dataFinal = Teclado.CapturaDataHoraDigitadaMaiorQueDataEspecifica(dataInicial);
         Console.WriteLine("Informe a Descrição");

--- a/Views/ViewMenus.cs
+++ b/Views/ViewMenus.cs
@@ -31,6 +31,7 @@ internal class ViewMenus
         Console.WriteLine("1 - Pesquisar Eventos Por Período");
         Console.WriteLine("2 - Pesquisar Eventos Em Uma Data Específica");
         Console.WriteLine("3 - Pesquisar Contato Cadastrado");
+        Console.WriteLine("4 - Listar Todos Os Eventos Cadastrados");
         Console.WriteLine("0 - Sair da Pesquisa");
         return Teclado.CapturaInteiroDigitado();
     }


### PR DESCRIPTION
Foi adicionado um método para listar todos os eventos cadastrados. Também houve correção da validação da data inicial inserida na adição de eventos; anteriormente, a mensagem de erro caso a data inicial digitada fosse menor que a data atual era mostrada apenas ao fim do cadastro de eventos e não pedia a entrada novamente.